### PR TITLE
fix overlap on list item of FAQ

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -772,7 +772,6 @@ button.btn-black:hover {
 
 .faq .faq-row ul {
 	list-style: disc;
-	line-height: 4px;
 	padding-left: 32px;
 }
 
@@ -809,10 +808,6 @@ button.btn-black:hover {
 	font-size: 14px;
 	font-weight: 400;
 	color: #888888;
-}
-
-.answer li {
-	padding: 8px;
 }
 
 .faq-row.expanded .answer {


### PR DESCRIPTION
解決FAQ中，`<ul> -> <li>` 多行的重疊問題

before
![Screenshot 2025-04-07 at 22-37-20 守護我們珍愛的臺灣，我們需要你！](https://github.com/user-attachments/assets/ad5fd4c9-63fa-41a4-a3dd-9cfc8bfedb0d)

after
![Screenshot 2025-04-07 at 22-37-31 守護我們珍愛的臺灣，我們需要你！](https://github.com/user-attachments/assets/6cc615b2-c5c7-42c4-ba96-2fec355062e9)
