### PR TITLE
replace URL of gov.tw with webarchive and text fragment

### DIFF
--- a/templates/tmpl.html
+++ b/templates/tmpl.html
@@ -196,7 +196,7 @@
 			<div class="answer">
 				選罷法並沒有規定所有連署書上的應記載項目均只能手寫。<br><br>依民法第 3 條第 1
 				項規定：「依法律之規定，有使用文字之必要者，得不由本人自寫，但必須親自簽名。」<br><br>依公職人員罷免案提議人及連署人名冊查對作業須知第參、二、(六)、3點：「提議人名冊之繕寫方式並未設限，於具備法定要件之前提下，提議人名冊經提議人簽名或蓋章者，即屬有效。」<br><br>因此只要選區正確、身分證資料正確，使用本網站填寫相關資料，列印下來後親自簽名，是符合規定的。<br><br>暸解詳細法規請至<a
-					href="https://law.cec.gov.tw/LawContent.aspx?id=GL000319" target="_blank">中選會網站</a>
+					href="https://web.archive.org/web/20250404044153/https://law.cec.gov.tw/LawContent.aspx?id=GL000319#:~:text=%E6%8F%90%E8%AD%B0%E4%BA%BA%E5%90%8D%E5%86%8A%E4%B9%8B%E7%B9%95%E5%AF%AB,%E5%8D%B3%E5%B1%AC%E6%9C%89%E6%95%88" target="_blank">中選會網站</a>
 			</div>
 		</li>
 		<li class="faq-row">


### PR DESCRIPTION
1. 主管法規查詢系統近期不穩定，可能是 HiNet CDN 的鍋，以 web.archive.org 的存檔取代
![Screenshot_2025-04-20-06-36-38_1920x1080](https://github.com/user-attachments/assets/8fcfcd07-5dd9-4420-87b9-106216860caf)

2. 使用 [text fragment](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments#syntax) 直接定位內容，目前所有瀏覽器[都支援此功能](https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments#browser_compatibility)
![Screenshot_2025-04-20-06-49-34_1920x1080](https://github.com/user-attachments/assets/f47b2419-16c2-4cec-ad21-ad97fec86256)

